### PR TITLE
Fix compilation issue when platform is implemented in C++

### DIFF
--- a/src/ucentral-client/include/router-utils.h
+++ b/src/ucentral-client/include/router-utils.h
@@ -46,16 +46,16 @@ struct ucentral_router {
 
 struct ucentral_router_fib_db_apply_args {
 	/* plat whould check info to determine if node channged */
-	int (*upd_cb)(const struct ucentral_router_fib_node *old,
+	int (*upd_cb)(const struct ucentral_router_fib_node *old_node,
 		      int olen,
-		      const struct ucentral_router_fib_node *new,
+		      const struct ucentral_router_fib_node *new_node,
 		      int nlen,
 		      void *arg);
 	/* prefix = new, info = new */
-	int (*add_cb)(const struct ucentral_router_fib_node *new,
+	int (*add_cb)(const struct ucentral_router_fib_node *new_node,
 		      int len, void *arg);
 	/* prefix = none */
-	int (*del_cb)(const struct ucentral_router_fib_node *old,
+	int (*del_cb)(const struct ucentral_router_fib_node *old_node,
 		      int len, void *arg);
 	void *arg;
 };


### PR DESCRIPTION
`new` variable name, used in [`router-utils.h`](https://github.com/r4nx/ols-ucentral-client/blob/6e8ccbf40c2f03f1b070bf5182d119f619d0cd6f/src/ucentral-client/include/router-utils.h#L51), conflicts with the `new` C++ keyword. That's why this header, as well as `ucentral-platform.h`, can't be included in C++ code.

PR fixes it by appending `_node` suffix to variable name. `old` renamed to `old_node` for consistency.