### PR TITLE
[OLS-563] Add version to ols-ucentral-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM debian:buster
 LABEL Description="Ucentral client (Build) environment"
 
 ARG HOME /root
-ARG EXTERNAL_LIBS ${HOME}/ucentral-external-libs
-ARG SCHEMA_COMMITID adeeb0457b7060d192e4180f96eca60d562d1d15
+ARG SCHEMA="3.2.7"
+ARG SCHEMA_VERSION="v${SCHEMA}"
+ARG SCHEMA_ZIP_FILE="${SCHEMA_VERSION}.zip"
+ARG SCHEMA_UNZIPPED="ols-ucentral-schema-${SCHEMA}"
+ARG OLS_SCHEMA_SRC="https://github.com/Telecominfraproject/ols-ucentral-schema/archive/refs/tags/${SCHEMA_ZIP_FILE}"
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -q -y  && apt-get -q -y --no-install-recommends install \
@@ -23,14 +26,16 @@ RUN apt-get update -q -y  && apt-get -q -y --no-install-recommends install \
 	autoconf \
 	libtool \
 	pkg-config \
-	libjsoncpp-dev
+	libjsoncpp-dev \
+        unzip
 
 RUN git config --global http.sslverify false
 RUN git clone https://github.com/DaveGamble/cJSON.git ${HOME}/ucentral-external-libs/cJSON/
 RUN git clone https://libwebsockets.org/repo/libwebsockets ${HOME}/ucentral-external-libs/libwebsockets/
 RUN git clone --recurse-submodules -b v1.50.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc ${HOME}/ucentral-external-libs/grpc/
 RUN git clone --recursive --branch v7.1.4 https://github.com/zhaojh329/rtty.git ${HOME}/ucentral-external-libs/rtty/
-RUN git clone https://github.com/Telecominfraproject/ols-ucentral-schema.git ${HOME}/ucentral-external-libs/ols-ucentral-schema/
+ADD ${OLS_SCHEMA_SRC} /tmp/
+
 
 # The following libs should be prebuilt in docker-build-env img to speed-up
 # recompilation of only the ucentral-client itself
@@ -64,6 +69,7 @@ RUN cd ${HOME}/ucentral-external-libs/rtty/ && \
 	cmake .. && \
 	make -j4
 
-RUN cd ${HOME}/ucentral-external-libs/ols-ucentral-schema/ && \
-        git checkout ${SCHEMA_COMMITID}
+RUN unzip /tmp/${SCHEMA_ZIP_FILE} -d ${HOME}/ucentral-external-libs/
 
+RUN cd ${HOME}/ucentral-external-libs/ && \
+    mv ${SCHEMA_UNZIPPED} ols-ucentral-schema


### PR DESCRIPTION
Dockerfile updated to pull tagged version of schema to get the schema.json file. This will make subsequent versioning much easier.

Once this is merged we can tag the client as 3.2.7 and then move forward to 4.x as we did with the schema.

example connect message using new Docker and schema
ucentral-client: callback_broker:476: TX:
```json
'{"jsonrpc":"2.0","method":"connect","params":{"serial":"e89f80ab1f4e","firmware":"Rel 3.2.7 Build 1","uuid":0,"capabilities":{"version":{"switch":{"major":3,"minor":2,"patch":7},"schema":{"major":3,"minor":2,"patch":7}},"serial":"e89f80ab1f4e","firmware":"Rel 3.2.7 Build 1","compatible":"example-platform-sku","model":"Example Platform","platform":"switch","label_macaddr":"e8:9f:80:ab:1f:4e"}}}'
```