### PR TITLE
OLS 410

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 LABEL Description="Ucentral client (Build) environment"
 
 ARG HOME /root
-ARG SCHEMA="4.0.0-rc1"
+ARG SCHEMA="4.1.0-rc1"
 ARG SCHEMA_VERSION="v${SCHEMA}"
 ARG SCHEMA_ZIP_FILE="${SCHEMA_VERSION}.zip"
 ARG SCHEMA_UNZIPPED="ols-ucentral-schema-${SCHEMA}"
@@ -47,6 +47,8 @@ RUN cd ${HOME}/ucentral-external-libs/cJSON/ && \
 	make install
 
 RUN cd ${HOME}/ucentral-external-libs/libwebsockets/ && \
+        git branch --all && \
+        git checkout a9b8fe7ebf61b8c0e7891e06e70d558412933a33 && \
 	mkdir build && \
 	cd build && \
 	cmake .. && \

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
 	"major": 4,
-	"minor": 0,
+	"minor": 1,
 	"patch": 0 
 }


### PR DESCRIPTION
Update version for OLS to 4.1.0
Update reference to OLS schema v4.1.0-rc1
Set libwebsockets to use a particular commit, in this case set to version used by previous ols-ucentral-client, just pulling can result in errors within the 3rd party library itself. That was happening with the most recent libwebsockets.

Validate connect now has 4.1.0 for both version and schema in message
ucentral-client: callback_broker:476: TX:
'
```JSON
{"jsonrpc":"2.0","method":"connect","params":{"serial":"e89f80ab1f4e","firmware":"Rel 4.1.0 Build rc1","uuid":0,"capabilities":{"version":{"switch":{"major":4,"minor":1,"patch":0},"schema":{"major":4,"minor":1,"patch":0}},"serial":"e89f80ab1f4e","firmware":"Rel 4.1.0 Build rc1","compatible":"example-platform-sku","model":"Example Platform","platform":"switch","label_macaddr":"e8:9f:80:ab:1f:4e"}}}
```
'