### PR TITLE
OLS-968:   Fix documentation accuracy and property database regeneration

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -142,14 +142,21 @@ make test-config-json USE_PLATFORM=brcm-sonic
 ### Key Files
 
 **Test Implementation:**
-- `tests/config-parser/test-config-parser.c` - Parser test framework with property tracking (628 properties)
-- `tests/config-parser/test-stubs.c` - Platform function stubs for testing
-- `tests/schema/validate-schema.py` - Standalone schema validator
+- `tests/config-parser/test-config-parser.c` (3304 lines) - Parser test framework with property tracking
+- `tests/config-parser/test-stubs.c` (219 lines) - Platform function stubs for stub mode testing
+- `tests/config-parser/platform-mocks/brcm-sonic.c` - gNMI/gNOI mocks for platform mode
+- `tests/config-parser/platform-mocks/example-platform.c` - Example platform mocks
+- `tests/schema/validate-schema.py` (649 lines) - Standalone schema validator with undefined property detection
 - `tests/config-parser/config-parser.h` - Test header exposing cfg_parse()
 
+**Property Database Files:**
+- `tests/config-parser/property-database-base.c` (416 lines) - Proto.c parsing (398 properties: 102 implemented, 296 not yet)
+- `tests/config-parser/property-database-platform-brcm-sonic.c` (419 lines) - Platform hardware application tracking
+- `tests/config-parser/property-database-platform-example.c` - Example platform database
+
 **Configuration Files:**
-- `config-samples/ols.ucentral.schema.pretty.json` - uCentral JSON schema (human-readable)
-- `config-samples/*.json` - Test configuration files (25+ configs)
+- `config-samples/ucentral.schema.pretty.json` - uCentral JSON schema (human-readable, single schema file)
+- `config-samples/*.json` - Test configuration files (25 configs)
 - `config-samples/*invalid*.json` - Negative test cases
 
 **Build System:**
@@ -202,12 +209,12 @@ See TEST_CONFIG_README.md section "Two-Layer Validation Strategy" for detailed e
 ## Test Coverage
 
 Current test suite includes:
-- 25+ configuration files covering various features
+- 25 configuration files covering various features
 - Positive tests (configs that should parse successfully)
 - Negative tests (configs that should fail)
 - Feature-specific validators for critical configurations
+- Two testing modes: stub mode (fast, proto.c only) and platform mode (integration, proto.c + platform code)
 - Platform stub with 54-port simulation (matches ECS4150 hardware)
-- All tests currently passing (25/25)
 
 ### Tested Features
 - Port configuration (enable/disable, speed, duplex)
@@ -236,17 +243,30 @@ These features pass schema validation but show as "Unknown" in property reports,
 The testing framework was added with minimal impact to production code:
 
 ### New Files Added
-1. `tests/config-parser/test-config-parser.c` - Complete test framework with 628-property database
-2. `tests/config-parser/test-stubs.c` - Platform stubs
-3. `tests/schema/validate-schema.py` - Schema validator
-4. `tests/config-parser/config-parser.h` - Test header
-5. `tests/config-parser/TEST_CONFIG_README.md` - Framework documentation
-6. `tests/schema/SCHEMA_VALIDATOR_README.md` - Validator documentation
-7. `tests/MAINTENANCE.md` - Maintenance procedures
-8. `tests/config-parser/Makefile` - Test build system
-9. `TESTING_FRAMEWORK.md` - This file (documentation index)
-10. `TEST_CONFIG_PARSER_DESIGN.md` - Test framework architecture and design
-11. `run-config-tests.sh` - Test runner script
+1. `tests/config-parser/test-config-parser.c` (3304 lines) - Complete test framework
+2. `tests/config-parser/test-stubs.c` (219 lines) - Platform stubs for stub mode
+3. `tests/config-parser/platform-mocks/brcm-sonic.c` - Platform mocks for brcm-sonic
+4. `tests/config-parser/platform-mocks/example-platform.c` - Platform mocks for example platform
+5. `tests/config-parser/property-database-base.c` (416 lines) - Base property database (398 properties: 102 implemented, 296 not yet)
+6. `tests/config-parser/property-database-platform-brcm-sonic.c` (419 lines) - Platform property database
+7. `tests/config-parser/property-database-platform-example.c` - Example platform property database
+8. `tests/schema/validate-schema.py` (649 lines) - Schema validator
+9. `tests/config-parser/config-parser.h` - Test header
+10. `tests/config-parser/TEST_CONFIG_README.md` - Framework documentation
+11. `tests/config-parser/platform-mocks/README.md` - Platform mocks documentation
+12. `tests/schema/SCHEMA_VALIDATOR_README.md` - Validator documentation
+13. `tests/MAINTENANCE.md` - Maintenance procedures
+14. `tests/ADDING_NEW_PLATFORM.md` - Platform addition guide
+15. `tests/config-parser/Makefile` - Test build system with stub and platform modes
+16. `tests/tools/extract-schema-properties.py` - Extract properties from schema
+17. `tests/tools/generate-database-from-schema.py` - Generate base property database
+18. `tests/tools/generate-platform-database-from-schema.py` - Generate platform property database
+19. `tests/README.md` - Testing framework overview
+20. `TESTING_FRAMEWORK.md` - This file (documentation index, in repository root)
+21. `TEST_CONFIG_PARSER_DESIGN.md` - Test framework architecture and design (in repository root)
+22. `QUICK_START_TESTING.md` - Quick start guide (in repository root)
+23. `TEST_RUNNER_README.md` - Test runner script documentation (in repository root)
+24. `run-config-tests.sh` - Test runner script (in repository root)
 
 ### Modified Files
 1. `src/ucentral-client/proto.c` - Added TEST_STATIC macro pattern (2 lines)
@@ -367,8 +387,7 @@ See MAINTENANCE.md for complete property database update procedures.
 The schema file defines what configurations are structurally valid.
 
 ### Schema Location
-- `config-samples/ucentral.schema.pretty.json` - Human-readable version (recommended)
-- `config-samples/ols.ucentral.schema.json` - Compact version
+- `config-samples/ucentral.schema.pretty.json` - Human-readable version (single schema file in repository)
 
 ### Schema Source
 Schema is maintained in the external [ols-ucentral-schema](https://github.com/Telecominfraproject/ols-ucentral-schema) repository.

--- a/tests/README.md
+++ b/tests/README.md
@@ -142,15 +142,14 @@ make test-config-json USE_PLATFORM=brcm-sonic
 ### Key Files
 
 **Test Implementation:**
-- `tests/config-parser/test-config-parser.c` (3445 lines) - Parser test framework with property tracking
-- `tests/config-parser/test-stubs.c` (214 lines) - Platform function stubs for testing
+- `tests/config-parser/test-config-parser.c` (3304 lines) - Parser test framework with property tracking
+- `tests/config-parser/test-stubs.c` (219 lines) - Platform function stubs for stub mode testing
 - `tests/schema/validate-schema.py` (649 lines) - Standalone schema validator with undefined property detection
 - `tests/config-parser/config-parser.h` - Test header exposing cfg_parse()
 
 **Configuration Files:**
-- `config-samples/ucentral.schema.pretty.json` - uCentral JSON schema (human-readable)
-- `config-samples/ols.ucentral.schema.json` - uCentral JSON schema (compact)
-- `config-samples/*.json` - Test configuration files (37+ configs)
+- `config-samples/ucentral.schema.pretty.json` - uCentral JSON schema (human-readable, single schema file)
+- `config-samples/*.json` - Test configuration files (25 configs total)
 - `config-samples/*invalid*.json` - Negative test cases
 
 **Build System:**
@@ -201,10 +200,11 @@ See TEST_CONFIG_README.md section "Two-Layer Validation Strategy" for detailed e
 ## Test Coverage
 
 Current test suite includes:
-- 37+ configuration files covering various features
+- 25 configuration files covering various features
 - Positive tests (configs that should parse successfully)
 - Negative tests (configs that should fail)
 - Feature-specific validators for critical configurations
+- Two testing modes: stub mode (fast, proto.c only) and platform mode (integration, proto.c + platform code)
 - Platform stub with 54-port simulation (matches ECS4150 hardware)
 
 ### Tested Features
@@ -234,17 +234,30 @@ These features pass schema validation but show as "Unknown" in property reports,
 The testing framework was added with minimal impact to production code:
 
 ### New Files Added
-1. `tests/config-parser/test-config-parser.c` - Complete test framework (3445 lines)
-2. `tests/config-parser/test-stubs.c` - Platform stubs (214 lines)
-3. `tests/schema/validate-schema.py` - Schema validator (649 lines)
-4. `tests/config-parser/config-parser.h` - Test header
-5. `tests/config-parser/TEST_CONFIG_README.md` - Framework documentation
-6. `tests/schema/SCHEMA_VALIDATOR_README.md` - Validator documentation
-7. `tests/MAINTENANCE.md` - Maintenance procedures
-8. `tests/config-parser/Makefile` - Test build system
-9. `tests/tools/` - Property database generation tools
-10. `TESTING_FRAMEWORK.md` - Documentation index (in repository root)
-11. `TEST_CONFIG_PARSER_DESIGN.md` - Test framework architecture and design (in repository root)
+1. `tests/config-parser/test-config-parser.c` (3304 lines) - Complete test framework
+2. `tests/config-parser/test-stubs.c` (219 lines) - Platform stubs for stub mode
+3. `tests/config-parser/platform-mocks/brcm-sonic.c` - Platform mocks for brcm-sonic
+4. `tests/config-parser/platform-mocks/example-platform.c` - Platform mocks for example platform
+5. `tests/config-parser/property-database-base.c` (416 lines) - Base property database (398 properties: 102 implemented, 296 not yet)
+6. `tests/config-parser/property-database-platform-brcm-sonic.c` (419 lines) - Platform property database
+7. `tests/config-parser/property-database-platform-example.c` - Example platform property database
+8. `tests/schema/validate-schema.py` (649 lines) - Schema validator
+9. `tests/config-parser/config-parser.h` - Test header
+10. `tests/config-parser/TEST_CONFIG_README.md` - Framework documentation
+11. `tests/config-parser/platform-mocks/README.md` - Platform mocks documentation
+12. `tests/schema/SCHEMA_VALIDATOR_README.md` - Validator documentation
+13. `tests/MAINTENANCE.md` - Maintenance procedures
+14. `tests/ADDING_NEW_PLATFORM.md` - Platform addition guide
+15. `tests/config-parser/Makefile` - Test build system with stub and platform modes
+16. `tests/tools/extract-schema-properties.py` - Extract properties from schema
+17. `tests/tools/generate-database-from-schema.py` - Generate base property database
+18. `tests/tools/generate-platform-database-from-schema.py` - Generate platform property database
+19. `tests/README.md` - This file (testing framework overview)
+20. `TESTING_FRAMEWORK.md` - Documentation index (in repository root)
+21. `TEST_CONFIG_PARSER_DESIGN.md` - Test framework architecture and design (in repository root)
+22. `QUICK_START_TESTING.md` - Quick start guide (in repository root)
+23. `TEST_RUNNER_README.md` - Test runner script documentation (in repository root)
+24. `run-config-tests.sh` - Test runner script (in repository root)
 
 ### Modified Files
 1. `src/ucentral-client/proto.c` - Added TEST_STATIC macro pattern (2 lines)
@@ -366,8 +379,7 @@ See MAINTENANCE.md for complete property database update procedures.
 The schema file defines what configurations are structurally valid.
 
 ### Schema Location
-- `config-samples/ucentral.schema.pretty.json` - Human-readable version (recommended)
-- `config-samples/ols.ucentral.schema.json` - Compact version
+- `config-samples/ucentral.schema.pretty.json` - Human-readable version (single schema file in repository)
 
 ### Schema Source
 Schema is maintained in the external [ols-ucentral-schema](https://github.com/Telecominfraproject/ols-ucentral-schema) repository.

--- a/tests/config-parser/Makefile
+++ b/tests/config-parser/Makefile
@@ -195,12 +195,15 @@ regenerate-property-db:
 	@echo "Regenerating base property database"
 	@echo "==========================================="
 	@echo "Source: ../../src/ucentral-client/proto.c"
-	@echo "Configs: ../../config-samples/cfg*.json"
+	@echo "Schema: ../../config-samples/ucentral.schema.pretty.json"
 	@echo "==========================================="
-	cd ../tools && python3 rebuild-property-database.py \
+	@cd ../tools && \
+	python3 extract-schema-properties.py ../../config-samples/ucentral.schema.pretty.json 2>/dev/null > /tmp/schema-props.txt && \
+	python3 generate-database-from-schema.py \
 		../../src/ucentral-client/proto.c \
-		../../config-samples/cfg*.json \
-		> ../config-parser/property-database-base.c
+		/tmp/schema-props.txt \
+		/tmp/base-db-new.c && \
+	cp /tmp/base-db-new.c ../config-parser/property-database-base.c
 	@echo "Base property database regenerated"
 	@echo "==========================================="
 
@@ -212,13 +215,16 @@ regenerate-platform-property-db:
 	@echo "Regenerating platform property database"
 	@echo "==========================================="
 	@echo "Platform: $(PLATFORM_NAME)"
-	@echo "Source:   ../../src/ucentral-client/platform/$(PLATFORM_NAME)/plat-*.c"
-	@echo "Configs:  ../../config-samples/cfg*.json"
+	@echo "Source:   ../../src/ucentral-client/platform/$(PLATFORM_NAME)/plat-gnma.c"
+	@echo "Schema:   ../../config-samples/ucentral.schema.pretty.json"
 	@echo "==========================================="
-	cd ../tools && python3 rebuild-property-database.py \
-		../../src/ucentral-client/platform/$(PLATFORM_NAME)/plat-*.c \
-		../../config-samples/cfg*.json \
-		> ../config-parser/property-database-platform-$(PLATFORM_NAME).c
+	@cd ../tools && \
+	python3 extract-schema-properties.py ../../config-samples/ucentral.schema.pretty.json 2>/dev/null > /tmp/schema-props.txt && \
+	python3 generate-platform-database-from-schema.py \
+		../../src/ucentral-client/platform/$(PLATFORM_NAME)/plat-gnma.c \
+		/tmp/schema-props.txt \
+		/tmp/platform-db-new.c && \
+	cp /tmp/platform-db-new.c ../config-parser/property-database-platform-$(PLATFORM_NAME).c
 	@echo "Platform property database regenerated"
 	@echo "==========================================="
 else

--- a/tests/config-parser/TEST_CONFIG_README.md
+++ b/tests/config-parser/TEST_CONFIG_README.md
@@ -679,9 +679,13 @@ The test suite uses a minimal-impact approach to expose `cfg_parse()` for testin
 
 ### Files
 
-- `test-config-parser.c` - Test framework and validators (3445 lines)
-- `test-stubs.c` - Platform function stubs for testing (214 lines)
-- `validate-schema.py` - Modular schema validation tool (305 lines)
+- `test-config-parser.c` - Test framework and validators (3304 lines)
+- `test-stubs.c` - Platform function stubs for stub mode testing (219 lines)
+- `platform-mocks/brcm-sonic.c` - Platform mocks for brcm-sonic integration testing
+- `platform-mocks/example-platform.c` - Platform mocks for example platform
+- `property-database-base.c` - Base property database (416 lines, 398 properties: 102 implemented, 296 not yet)
+- `property-database-platform-brcm-sonic.c` - Platform property database (419 lines)
+- `validate-schema.py` - Modular schema validation tool (649 lines)
 - `include/config-parser.h` - Header declaring cfg_parse
 - `Makefile` - Test targets: test-config, validate-schema, test-config-full
 - `proto.c` - Added TEST_STATIC macro pattern (2 lines modified)


### PR DESCRIPTION
  Hopefully the last changes for a while, mostly documentation and an old ref in the tests makefile targets.
  At this point everything tests wise should be on point and aligned with the documentation.
  
  - Update line counts across documentation to match actual source files (test-config-parser.c: 3304 lines, test-stubs.c: 219 lines)
  - Correct test configuration count to exact "25 configs"
  - Fix schema file references to single canonical file
  - Add property database documentation with accurate statistics
  - Fix broken Makefile regeneration targets (regenerate-property-db, regenerate-platform-property-db) to use correct schema-based workflow
  - Replace non-existent rebuild-property-database.py with three-step process: extract-schema-properties.py → generate-database-from-schema.py