### PR TITLE
[OLS-1077] EST reenroll: detect server from birth cert and warn on un…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,10 @@ RUN cd ${HOME}/ucentral-external-libs/rtty/ && \
 	cmake .. && \
 	make -j4
 
-RUN unzip /tmp/${SCHEMA_ZIP_FILE} -d ${HOME}/ucentral-external-libs/
+RUN unzip /tmp/$(basename ${SCHEMA_ZIP_FILE}) -d ${HOME}/ucentral-external-libs/
 
 RUN cd ${HOME}/ucentral-external-libs/ && \
-    mv ${SCHEMA_UNZIPPED} ols-ucentral-schema
+    mv ${SCHEMA_UNZIPPED//\//-} ols-ucentral-schema
 
 # Copy version files to /etc/ for runtime use
 COPY version.json /etc/version.json

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ all: build-host-env build-ucentral-app build-ucentral-docker-img build-final-deb
 build-host-env:
 	@mkdir output 2>/dev/null || true
 	@mkdir docker 2>/dev/null || true
+	cp version.json docker/version.json
 	# Build docker img if not exists already, do nothing otherwise;
 	@echo Checking / building docker build env img;
 	docker inspect --type=image ${IMG_ID}:${IMG_TAG} >/dev/null 2>&1 || \

--- a/docker-build-client.sh
+++ b/docker-build-client.sh
@@ -31,7 +31,7 @@ ldconfig
 
 echo "Making ucentral-client application..."
 cd $HOME/ucentral/
-{ make clean && make test && make UCENTRAL_PLATFORM=$UCENTRAL_PLATFORM -j4; } || exit 1;
+{ make test && make UCENTRAL_PLATFORM=$UCENTRAL_PLATFORM -j4; } || exit 1;
 
 echo "Installing ucentral-client to /root/deliverables"
 cp ucentral-client /root/deliverables/

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN echo "uCentral client support"
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/src/ucentral-client/est-client.c
+++ b/src/ucentral-client/est-client.c
@@ -24,6 +24,9 @@
 #include <openssl/evp.h>
 #include <openssl/pkcs7.h>
 
+#define UC_LOG_COMPONENT UC_LOG_COMPONENT_CLIENT
+#include "ucentral-log.h"
+
 #include "est-client.h"
 
 /* EST default servers */
@@ -124,10 +127,14 @@ const char* est_get_server_url(const char *cert_path)
 	if (env_server && env_server[0])
 		return env_server;
 
-	/* Auto-detect from certificate issuer */
+	/* Caller must pass the birth cert; operational cert issuers are not
+	 * matched below. */
 	char *issuer = est_get_cert_issuer(cert_path);
-	if (!issuer)
-		return EST_SERVER_PROD; /* default fallback */
+	if (!issuer) {
+		UC_LOG_INFO("EST: cert issuer unavailable, defaulting to %s\n",
+			    EST_SERVER_PROD);
+		return EST_SERVER_PROD;
+	}
 
 	const char *server = EST_SERVER_PROD;
 
@@ -135,6 +142,9 @@ const char* est_get_server_url(const char *cert_path)
 		server = EST_SERVER_QA;
 	} else if (strstr(issuer, "OpenLAN Birth Issuing CA")) {
 		server = EST_SERVER_PROD;
+	} else {
+		UC_LOG_INFO("EST: unrecognized cert issuer '%s', defaulting to %s\n",
+			    issuer, EST_SERVER_PROD);
 	}
 
 	OPENSSL_free(issuer);

--- a/src/ucentral-client/est-client.c
+++ b/src/ucentral-client/est-client.c
@@ -127,16 +127,16 @@ const char* est_get_server_url(const char *cert_path)
 	if (env_server && env_server[0])
 		return env_server;
 
+	const char *server = EST_SERVER_PROD;
+
 	/* Caller must pass the birth cert; operational cert issuers are not
 	 * matched below. */
 	char *issuer = est_get_cert_issuer(cert_path);
 	if (!issuer) {
 		UC_LOG_INFO("EST: cert issuer unavailable, defaulting to %s\n",
-			    EST_SERVER_PROD);
-		return EST_SERVER_PROD;
+			    server);
+		return server;
 	}
-
-	const char *server = EST_SERVER_PROD;
 
 	if (strstr(issuer, "OpenLAN Demo Birth CA")) {
 		server = EST_SERVER_QA;
@@ -144,7 +144,7 @@ const char* est_get_server_url(const char *cert_path)
 		server = EST_SERVER_PROD;
 	} else {
 		UC_LOG_INFO("EST: unrecognized cert issuer '%s', defaulting to %s\n",
-			    issuer, EST_SERVER_PROD);
+			    issuer, server);
 	}
 
 	OPENSSL_free(issuer);

--- a/src/ucentral-client/proto.c
+++ b/src/ucentral-client/proto.c
@@ -2382,6 +2382,7 @@ reenroll_handle(cJSON **rpc)
 	double id = 0;
 	char *renewed_cert = NULL;
 	int ret;
+	const char *birth_cert = UCENTRAL_CONFIG "cert.pem";
 	const char *operational_cert = UCENTRAL_CONFIG "operational.pem";
 	const char *key_path = UCENTRAL_CONFIG "key.pem";
 	const char *ca_bundle = UCENTRAL_CONFIG "cas.pem";
@@ -2400,8 +2401,7 @@ reenroll_handle(cJSON **rpc)
 		return;
 	}
 
-	/* Auto-detect EST server from certificate issuer */
-	est_server = est_get_server_url(operational_cert);
+	est_server = est_get_server_url(birth_cert);
 	if (!est_server) {
 		UC_LOG_ERR("reenroll: Failed to detect EST server URL\n");
 		action_reply(1, "Failed to detect EST server", 1, id);


### PR DESCRIPTION
…known issuer

reenroll_handle() passed operational.pem into est_get_server_url(), but the issuer-CN match recognises only birth-CA names. Operational certs are signed by an Operating CA, so detection always fell through to the EST_SERVER_PROD default -- Demo devices were misrouted to prod, and Production devices worked only by accident.

Pass cert.pem (birth cert) into est_get_server_url(); reenroll itself still uses operational.pem. Add UC_LOG_INFO on unreadable and unrecognised issuer paths so silent fall-through is visible in syslog. Unrecognised-issuer-keeps-default behaviour is retained to stay consistent with wlan-ap's three-way classification.

End-to-end build verification on a fresh host also required several latent build-environment fixes (top-level Makefile/Dockerfile, runtime debian:buster -> debian:bullseye, redundant make clean removed) so 'make all' completes against modern Docker.

Refs: https://github.com/Telecominfraproject/ols-ucentral-client/issues/27